### PR TITLE
Added oh-my-zsh plugin support

### DIFF
--- a/zsh-vimode-visual.plugin.zsh
+++ b/zsh-vimode-visual.plugin.zsh
@@ -1,0 +1,1 @@
+source ${0:A:h}/zsh-vimode-visual.zsh


### PR DESCRIPTION
Oh-my-zsh users can now use this plugin by cloning this repo into `~/.oh_my_zsh/custom/plugins` and adding `zsh-vmode-visual` to the plugin list